### PR TITLE
feat: 모든 프로젝트에 케이스 스터디 상세 페이지 및 분야별 포트폴리오 구조 추가

### DIFF
--- a/components/WorkCard.tsx
+++ b/components/WorkCard.tsx
@@ -4,8 +4,9 @@ import { useState } from 'react';
 import Image from 'next/image';
 import Link from 'next/link';
 import { motion } from 'framer-motion';
-import { ExternalLink, ArrowRight } from 'lucide-react';
+import { ArrowRight } from 'lucide-react';
 import type { WorkProject } from '@/lib/worksData';
+import { categoryLabels } from '@/lib/worksData';
 
 interface WorkCardProps {
   project: WorkProject;
@@ -15,92 +16,71 @@ export default function WorkCard({ project }: WorkCardProps) {
   const [imgError, setImgError] = useState(false);
   const showImage = project.image && !imgError;
 
-  const cardClassName =
-    'group relative flex flex-col overflow-hidden rounded-2xl bg-white/5 border border-white/10 transition-colors duration-300 hover:bg-white/10 hover:border-white/20';
+  return (
+    <Link href={`/works/${project.id}`} className="block h-full">
+      <motion.div
+        className="group relative flex h-full flex-col overflow-hidden rounded-2xl bg-white/5 border border-white/10 transition-colors duration-300 hover:bg-white/10 hover:border-white/20"
+        whileHover={{
+          scale: 1.03,
+          boxShadow: `0 0 40px ${project.accentColor}`,
+        }}
+        transition={{ type: 'spring', stiffness: 300, damping: 20 }}
+      >
+        {/* Preview Image / Fallback */}
+        <div className="aspect-video w-full relative overflow-hidden">
+          {showImage ? (
+            <Image
+              src={project.image!}
+              alt={project.title}
+              fill
+              className="object-cover transition-transform duration-500 group-hover:scale-110"
+              unoptimized
+              onError={() => setImgError(true)}
+            />
+          ) : (
+            <div
+              className={`absolute inset-0 bg-gradient-to-br ${project.fallbackGradient} flex items-center justify-center`}
+            >
+              <span className="text-2xl font-bold text-white/30 group-hover:text-white/60 transition-colors duration-300">
+                {project.fallbackLabel}
+              </span>
+            </div>
+          )}
 
-  const motionProps = {
-    whileHover: {
-      scale: 1.03,
-      boxShadow: `0 0 40px ${project.accentColor}`,
-    },
-    transition: { type: 'spring' as const, stiffness: 300, damping: 20 },
-  };
+          {/* Category badge */}
+          <span className="absolute top-3 left-3 text-[10px] font-semibold uppercase tracking-widest px-2.5 py-1 rounded-full bg-black/40 backdrop-blur-sm border border-white/20 text-white/90">
+            {categoryLabels[project.type]}
+          </span>
 
-  const HoverIcon = project.type === 'app' ? ArrowRight : ExternalLink;
-
-  const cardContent = (
-    <>
-      {/* Preview Image / Fallback */}
-      <div className="aspect-video w-full relative overflow-hidden">
-        {showImage ? (
-          <Image
-            src={project.image!}
-            alt={project.title}
-            fill
-            className="object-cover transition-transform duration-500 group-hover:scale-110"
-            unoptimized
-            onError={() => setImgError(true)}
-          />
-        ) : (
-          <div
-            className={`absolute inset-0 bg-gradient-to-br ${project.fallbackGradient} flex items-center justify-center`}
-          >
-            <span className="text-2xl font-bold text-white/30 group-hover:text-white/60 transition-colors duration-300">
-              {project.fallbackLabel}
+          {/* Hover overlay */}
+          <div className="absolute inset-0 bg-black/0 group-hover:bg-black/30 transition-colors duration-300 flex items-center justify-center">
+            <span className="inline-flex items-center gap-2 text-sm font-medium text-white opacity-0 group-hover:opacity-100 transition-opacity duration-300">
+              View Case Study
+              <ArrowRight size={16} />
             </span>
           </div>
-        )}
-
-        {/* Hover overlay with icon */}
-        <div className="absolute inset-0 bg-black/0 group-hover:bg-black/30 transition-colors duration-300 flex items-center justify-center">
-          <HoverIcon
-            size={28}
-            className="text-white opacity-0 group-hover:opacity-100 transition-opacity duration-300"
-          />
         </div>
-      </div>
 
-      {/* Content */}
-      <div className="p-6 flex flex-col flex-1">
-        <h2 className="text-xl font-semibold text-white/90 group-hover:text-white mb-2 transition-colors">
-          {project.title}
-        </h2>
-        <p className="text-sm text-white/60 mb-4 line-clamp-2 leading-relaxed">
-          {project.description}
-        </p>
-        <div className="flex flex-wrap gap-2 mt-auto">
-          {project.tags.map((tag) => (
-            <span
-              key={tag}
-              className="text-xs font-medium px-3 py-1 rounded-full bg-white/10 text-white/70"
-            >
-              {tag}
-            </span>
-          ))}
+        {/* Content */}
+        <div className="p-6 flex flex-col flex-1">
+          <h2 className="text-xl font-semibold text-white/90 group-hover:text-white mb-2 transition-colors">
+            {project.title}
+          </h2>
+          <p className="text-sm text-white/60 mb-4 line-clamp-2 leading-relaxed">
+            {project.description}
+          </p>
+          <div className="flex flex-wrap gap-2 mt-auto">
+            {project.tags.map((tag) => (
+              <span
+                key={tag}
+                className="text-xs font-medium px-3 py-1 rounded-full bg-white/10 text-white/70"
+              >
+                {tag}
+              </span>
+            ))}
+          </div>
         </div>
-      </div>
-    </>
-  );
-
-  if (project.type === 'app') {
-    return (
-      <Link href={`/works/${project.id}`} className="block">
-        <motion.div className={cardClassName} {...motionProps}>
-          {cardContent}
-        </motion.div>
-      </Link>
-    );
-  }
-
-  return (
-    <motion.a
-      href={project.url}
-      target="_blank"
-      rel="noopener noreferrer"
-      className={cardClassName}
-      {...motionProps}
-    >
-      {cardContent}
-    </motion.a>
+      </motion.div>
+    </Link>
   );
 }

--- a/lib/worksData.ts
+++ b/lib/worksData.ts
@@ -33,6 +33,63 @@ export interface MarketingContent {
   ctaUrl: string;
 }
 
+// ─── Case Study (shared by every project) ───
+
+export interface CaseStudyOverview {
+  summary: string;
+  challenge: string;
+  approach: string;
+  scope: string[];
+}
+
+export interface DesignColor {
+  name: string;
+  hex: string;
+  role: string;
+}
+
+export interface DesignTypography {
+  family: string;
+  usage: string;
+}
+
+export interface DesignPrinciple {
+  title: string;
+  description: string;
+}
+
+export interface DesignSystem {
+  concept: string;
+  colors: DesignColor[];
+  typography: DesignTypography[];
+  principles: DesignPrinciple[];
+}
+
+export interface CaseStudyLink {
+  label: string;
+  url: string;
+  description: string;
+}
+
+export interface CaseStudy {
+  tagline: string;
+  overview: CaseStudyOverview;
+  designSystem: DesignSystem;
+  techStack: string[];
+  deliverables: string[];
+  links: CaseStudyLink[];
+}
+
+// ─── Categories ───
+
+export type WorkCategory = 'web' | 'app' | 'design';
+
+export const categoryLabels: Record<WorkCategory, string> = {
+  web: 'Web',
+  app: 'App',
+  design: 'Design',
+};
+
 // ─── Discriminated Union ───
 
 interface WorkProjectBase {
@@ -45,10 +102,15 @@ interface WorkProjectBase {
   fallbackGradient: string;
   fallbackLabel: string;
   accentColor: string;
+  caseStudy: CaseStudy;
 }
 
 export interface WebProject extends WorkProjectBase {
   type: 'web';
+}
+
+export interface DesignProject extends WorkProjectBase {
+  type: 'design';
 }
 
 export interface AppProject extends WorkProjectBase {
@@ -61,7 +123,7 @@ export interface AppProject extends WorkProjectBase {
   privacy: PrivacyContent;
 }
 
-export type WorkProject = WebProject | AppProject;
+export type WorkProject = WebProject | AppProject | DesignProject;
 
 // ─── Data ───
 
@@ -78,6 +140,42 @@ export const worksData: WorkProject[] = [
     fallbackGradient: 'from-amber-900 via-orange-800 to-yellow-900',
     fallbackLabel: 'ddubakehouse',
     accentColor: 'rgba(245, 158, 11, 0.4)',
+    caseStudy: {
+      tagline: 'A warm digital storefront for a Jeju bakery brand.',
+      overview: {
+        summary:
+          'Ddu Bakehouse needed more than a menu page — it needed a website that feels like walking into the bakery itself. We designed and built a brand-driven web experience that translates the warmth of freshly baked bread into color, typography, and motion.',
+        challenge:
+          'Local bakeries rarely stand out online. The brand\'s handmade, cozy identity had to survive the transition to a digital medium without feeling generic or template-like.',
+        approach:
+          'We started from the brand\'s physical identity — warm tones, natural textures, handwritten touches — and built a design system around it. Every section was crafted to showcase products photogenically while keeping load times fast on mobile.',
+        scope: ['Brand-driven UI design', 'Responsive web development', 'Product showcase', 'Location & contact experience'],
+      },
+      designSystem: {
+        concept:
+          'The visual language borrows directly from the bakery: butter, toast, and cream tones over a warm charcoal base, paired with generous whitespace so product photography stays the hero.',
+        colors: [
+          { name: 'Butter Amber', hex: '#F59E0B', role: 'Primary accent & CTAs' },
+          { name: 'Toasted Brown', hex: '#78350F', role: 'Depth & section contrast' },
+          { name: 'Cream', hex: '#FEF3C7', role: 'Highlight surfaces' },
+          { name: 'Warm Charcoal', hex: '#1C1917', role: 'Base background & text' },
+        ],
+        typography: [
+          { family: 'Pretendard', usage: 'Korean body text & UI — clean, highly legible on every device' },
+          { family: 'Serif Display', usage: 'Headlines — adds an artisanal, handcrafted character' },
+        ],
+        principles: [
+          { title: 'Photography first', description: 'Layouts frame product photos as the main content; UI stays quiet around them.' },
+          { title: 'Warmth over polish', description: 'Rounded corners, soft shadows, and warm hues keep the experience approachable.' },
+          { title: 'Mobile-first pace', description: 'Most visitors arrive from maps and social links on mobile, so every flow starts there.' },
+        ],
+      },
+      techStack: ['Next.js', 'React', 'TypeScript', 'Tailwind CSS', 'Vercel'],
+      deliverables: ['UI/UX design', 'Design system', 'Frontend development', 'SEO & deployment'],
+      links: [
+        { label: 'Live Website', url: 'https://ddubakehouse.com', description: 'Visit the production site' },
+      ],
+    },
   },
   {
     type: 'web',
@@ -91,6 +189,42 @@ export const worksData: WorkProject[] = [
     fallbackGradient: 'from-emerald-900 via-green-800 to-teal-900',
     fallbackLabel: '로또풀이',
     accentColor: 'rgba(16, 185, 129, 0.4)',
+    caseStudy: {
+      tagline: 'Traditional fortune-telling meets playful modern UX.',
+      overview: {
+        summary:
+          '로또풀이 turns Korean saju fortune-telling into an entertaining lottery-number experience. The product needed to feel fun and lighthearted while handling a genuinely complex domain — traditional four-pillars analysis — under the hood.',
+        challenge:
+          'Saju terminology is dense and unfamiliar to younger users. Presenting it raw would alienate the audience; oversimplifying it would lose the charm that makes the service unique.',
+        approach:
+          'We layered the experience: a playful, game-like surface for casual users, with progressively deeper explanations for the curious. Motion and micro-interactions carry the "reveal" moments that make fortune results feel special.',
+        scope: ['Service concept & UX flow', 'Interactive result experience', 'Responsive web development', 'Korean IDN domain setup'],
+      },
+      designSystem: {
+        concept:
+          'Jade and gold — colors of luck and prosperity in Korean tradition — reinterpreted on a dark modern canvas. The palette signals fortune without falling into old-fashioned clichés.',
+        colors: [
+          { name: 'Lucky Jade', hex: '#10B981', role: 'Primary accent & result highlights' },
+          { name: 'Deep Forest', hex: '#064E3B', role: 'Section backgrounds' },
+          { name: 'Coin Gold', hex: '#FBBF24', role: 'Fortune moments & emphasis' },
+          { name: 'Night Ink', hex: '#0F172A', role: 'Base background' },
+        ],
+        typography: [
+          { family: 'Pretendard', usage: 'Body & UI text — optimized for Korean readability' },
+          { family: 'Rounded Display', usage: 'Numbers & results — friendly, game-like personality' },
+        ],
+        principles: [
+          { title: 'Delight in the reveal', description: 'Fortune results animate in with anticipation — the core emotional beat of the product.' },
+          { title: 'Serious engine, playful surface', description: 'Complex saju logic stays invisible; users only feel the fun.' },
+          { title: 'One-thumb flows', description: 'Every interaction is reachable and completable with one thumb on mobile.' },
+        ],
+      },
+      techStack: ['Next.js', 'React', 'TypeScript', 'Tailwind CSS', 'Framer Motion'],
+      deliverables: ['UX design', 'Interaction design', 'Frontend development', 'Saju analysis integration'],
+      links: [
+        { label: 'Live Website', url: 'https://로또풀이.kr', description: 'Visit the production site' },
+      ],
+    },
   },
   {
     type: 'web',
@@ -104,6 +238,42 @@ export const worksData: WorkProject[] = [
     fallbackGradient: 'from-blue-900 via-indigo-800 to-purple-900',
     fallbackLabel: 'econalk',
     accentColor: 'rgba(99, 102, 241, 0.4)',
+    caseStudy: {
+      tagline: 'AI-generated economic insight, readable in any language.',
+      overview: {
+        summary:
+          'Econalk is an AI-powered news platform that analyzes economic events and delivers insights in multiple languages. The product combines automated content pipelines with an editorial-grade reading experience.',
+        challenge:
+          'AI-generated content platforms often feel low-trust. Econalk had to look and read like a credible publication while the content pipeline runs fully automated, across languages with very different typographic needs.',
+        approach:
+          'We designed an editorial layout system — clear hierarchy, disciplined type scale, restrained color — that holds up across languages and scripts. The AI pipeline was shaped to produce structured content that slots cleanly into these layouts.',
+        scope: ['Editorial design system', 'Multilingual UX architecture', 'AI content pipeline integration', 'SEO-oriented development'],
+      },
+      designSystem: {
+        concept:
+          'A news-desk aesthetic: indigo authority tones on deep navy, with a strict typographic grid. Color is used sparingly so data and headlines carry the hierarchy.',
+        colors: [
+          { name: 'Insight Indigo', hex: '#6366F1', role: 'Primary accent & links' },
+          { name: 'Midnight Navy', hex: '#1E1B4B', role: 'Header & section backgrounds' },
+          { name: 'Signal Sky', hex: '#38BDF8', role: 'Data highlights & charts' },
+          { name: 'Slate Black', hex: '#0F172A', role: 'Base background' },
+        ],
+        typography: [
+          { family: 'Multiscript Sans', usage: 'Body — consistent rhythm across Korean, Latin, and CJK scripts' },
+          { family: 'Condensed Display', usage: 'Headlines — dense, newsroom-style hierarchy' },
+        ],
+        principles: [
+          { title: 'Credibility by design', description: 'Editorial discipline — grids, consistent spacing, restrained color — builds trust in automated content.' },
+          { title: 'Language-agnostic layout', description: 'Every component tolerates text expansion and different scripts without breaking.' },
+          { title: 'Scannable density', description: 'Readers skim; hierarchy lets them find the one insight they came for in seconds.' },
+        ],
+      },
+      techStack: ['Next.js', 'React', 'TypeScript', 'Tailwind CSS', 'LLM Pipeline', 'i18n'],
+      deliverables: ['Editorial design system', 'Multilingual architecture', 'AI pipeline integration', 'Frontend development'],
+      links: [
+        { label: 'Live Website', url: 'https://econalk.com', description: 'Visit the production site' },
+      ],
+    },
   },
   {
     type: 'web',
@@ -117,6 +287,42 @@ export const worksData: WorkProject[] = [
     fallbackGradient: 'from-violet-900 via-purple-800 to-fuchsia-900',
     fallbackLabel: 'sajulens',
     accentColor: 'rgba(168, 85, 247, 0.4)',
+    caseStudy: {
+      tagline: 'The four pillars of destiny, interpreted by AI.',
+      overview: {
+        summary:
+          'SajuLens reinterprets traditional Korean four-pillars analysis through AI, delivering personalized readings in a modern, approachable interface. Depth of tradition, clarity of a modern product.',
+        challenge:
+          'Saju readings are long-form and interpretive. Turning an AI-generated reading into something that feels personal, trustworthy, and worth reading to the end — rather than a wall of generated text — was the core design problem.',
+        approach:
+          'Readings are broken into a guided, sectioned journey with visual anchors for each pillar. A mystic-but-modern visual identity keeps the experience atmospheric without becoming kitsch.',
+        scope: ['Product & UX design', 'AI reading experience', 'Responsive web development', 'Brand identity'],
+      },
+      designSystem: {
+        concept:
+          'Amethyst and violet on a near-black night sky — mysticism rendered with modern gradients and glassmorphism instead of traditional ornament.',
+        colors: [
+          { name: 'Amethyst', hex: '#A855F7', role: 'Primary accent & highlights' },
+          { name: 'Deep Violet', hex: '#4C1D95', role: 'Section depth & gradients' },
+          { name: 'Fuchsia Glow', hex: '#E879F9', role: 'Mystic emphasis moments' },
+          { name: 'Night Sky', hex: '#0C0518', role: 'Base background' },
+        ],
+        typography: [
+          { family: 'Pretendard', usage: 'Body & readings — sustained readability for long-form text' },
+          { family: 'Elegant Serif', usage: 'Pillar titles — a ceremonial, timeless voice' },
+        ],
+        principles: [
+          { title: 'Guided journey', description: 'Long readings become a paced, sectioned experience with a clear sense of progress.' },
+          { title: 'Modern mysticism', description: 'Gradients, glass, and glow express the mystical — no clichéd fortune-teller motifs.' },
+          { title: 'Personal weight', description: 'Layout and motion treat each reading as a document made for one person.' },
+        ],
+      },
+      techStack: ['Next.js', 'React', 'TypeScript', 'Tailwind CSS', 'LLM Integration'],
+      deliverables: ['Brand identity', 'UX design', 'AI reading pipeline', 'Frontend development'],
+      links: [
+        { label: 'Live Website', url: 'https://sajulens.com', description: 'Visit the production site' },
+      ],
+    },
   },
   {
     type: 'web',
@@ -130,6 +336,42 @@ export const worksData: WorkProject[] = [
     fallbackGradient: 'from-teal-900 via-cyan-800 to-sky-900',
     fallbackLabel: 'jejuway',
     accentColor: 'rgba(20, 184, 166, 0.4)',
+    caseStudy: {
+      tagline: 'Find your own way around Jeju Island.',
+      overview: {
+        summary:
+          'JejuWay is a travel companion for exploring Jeju Island — curated routes, hidden spots, and local recommendations, organized so travelers can build their own way instead of following a fixed itinerary.',
+        challenge:
+          'Travel content is abundant but fragmented. The product had to organize scattered local knowledge into browsable, trustworthy curation — and feel like Jeju, not like a generic travel aggregator.',
+        approach:
+          'We built the information architecture around routes and moments rather than listings. The visual identity draws from Jeju itself: ocean teals, basalt darks, and photography-forward layouts.',
+        scope: ['Information architecture', 'Curation UX design', 'Responsive web development', 'Local content strategy'],
+      },
+      designSystem: {
+        concept:
+          'Jeju\'s landscape as a palette — ocean teal, deep basalt, and cyan sky — with airy, photography-led layouts that let the island sell itself.',
+        colors: [
+          { name: 'Jeju Teal', hex: '#14B8A6', role: 'Primary accent & navigation' },
+          { name: 'Ocean Cyan', hex: '#06B6D4', role: 'Interactive highlights' },
+          { name: 'Basalt', hex: '#134E4A', role: 'Depth & card surfaces' },
+          { name: 'Deep Sea', hex: '#042F2E', role: 'Base background' },
+        ],
+        typography: [
+          { family: 'Pretendard', usage: 'UI & descriptions — clarity for on-the-go reading' },
+          { family: 'Humanist Display', usage: 'Place names & headers — a warm, guidebook voice' },
+        ],
+        principles: [
+          { title: 'Place before interface', description: 'Photography and place identity lead every screen; chrome stays minimal.' },
+          { title: 'Routes, not lists', description: 'Content is structured as journeys — how spots connect matters as much as the spots.' },
+          { title: 'Trust through locality', description: 'Local voice and specific detail differentiate curation from aggregation.' },
+        ],
+      },
+      techStack: ['Next.js', 'React', 'TypeScript', 'Tailwind CSS', 'Map Integration'],
+      deliverables: ['Information architecture', 'UI/UX design', 'Frontend development', 'Content structure'],
+      links: [
+        { label: 'Live Website', url: 'https://jejuway.com', description: 'Visit the production site' },
+      ],
+    },
   },
   {
     type: 'app',
@@ -146,6 +388,42 @@ export const worksData: WorkProject[] = [
     subtitle: 'A visual diary for daily moments.',
     heroDescription:
       'Memoire is an Instagram-style visual diary app that lets you record daily memories with photos and text. Browse entries on an infinite-scroll calendar, generate magazine-style PDF books, customize themes, and sync seamlessly across devices via iCloud or Google Drive — all with a local-first, privacy-focused architecture.',
+    caseStudy: {
+      tagline: 'A visual diary that turns daily moments into keepsakes.',
+      overview: {
+        summary:
+          'Memoire is a cross-platform visual diary app for iOS and Android. Users capture daily moments with photos and text, browse them on an infinite-scroll calendar, and export magazine-style PDF books — with a local-first architecture that keeps personal data on the user\'s own device and cloud.',
+        challenge:
+          'Diary apps live or die on daily retention and trust. The app had to make journaling feel effortless and rewarding every day, while guaranteeing privacy — no personal content on our servers — without sacrificing multi-device sync.',
+        approach:
+          'A local-first architecture with per-platform cloud sync (iCloud / Google Drive) solved the trust problem structurally. On the experience side, we invested in the emotional payoff: beautiful entry layouts, theme customization, and the PDF book as a tangible reward for consistent journaling.',
+        scope: ['Product design', 'iOS & Android development', 'Local-first sync architecture', 'PDF generation engine', '16-language localization'],
+      },
+      designSystem: {
+        concept:
+          'Soft rose and blush tones create an intimate, personal atmosphere — a diary should feel like a private space, not a social feed. Five built-in themes let each user make it their own.',
+        colors: [
+          { name: 'Memoire Rose', hex: '#F43F5E', role: 'Primary accent & actions' },
+          { name: 'Blush', hex: '#FDA4AF', role: 'Soft highlights & moods' },
+          { name: 'Deep Plum', hex: '#831843', role: 'Depth & dark theme accents' },
+          { name: 'Paper', hex: '#FFF1F2', role: 'Light surfaces & book pages' },
+        ],
+        typography: [
+          { family: 'System Sans (SF Pro / Roboto)', usage: 'UI — native feel on each platform' },
+          { family: 'Serif Book', usage: 'PDF book exports — a printed-keepsake character' },
+        ],
+        principles: [
+          { title: 'Effortless capture', description: 'A new entry — photo, mood, weather, text — takes under a minute, every day.' },
+          { title: 'Privacy as architecture', description: 'Local-first storage and user-owned cloud sync make privacy structural, not a policy promise.' },
+          { title: 'Memories as artifacts', description: 'Calendar browsing and PDF books turn scattered entries into something worth keeping.' },
+        ],
+      },
+      techStack: ['Flutter', 'Dart', 'Riverpod', 'Drift (SQLite)', 'Firebase', 'iCloud', 'Google Drive', 'PDF Generation'],
+      deliverables: ['Product design', 'Cross-platform app development', 'Sync architecture', 'App Store launch', 'Localization (16 languages)'],
+      links: [
+        { label: 'App Store', url: 'https://apps.apple.com/kr/app/memoire-%EB%82%98%EB%A7%8C%EC%9D%98-%EA%B0%90%EC%84%B1-%EB%8B%A4%EC%9D%B4%EC%96%B4%EB%A6%AC/id6759441421', description: 'Download for iOS' },
+      ],
+    },
     spec: {
       headline: 'What is Memoire?',
       introduction:
@@ -284,10 +562,19 @@ export const worksData: WorkProject[] = [
 
 // ─── Helpers ───
 
+export function getProjectById(id: string): WorkProject | undefined {
+  return worksData.find((p) => p.id === id);
+}
+
 export function getAppProjects(): AppProject[] {
   return worksData.filter((p): p is AppProject => p.type === 'app');
 }
 
 export function getAppProjectById(id: string): AppProject | undefined {
   return getAppProjects().find((p) => p.id === id);
+}
+
+export function getCategories(): WorkCategory[] {
+  const present = new Set(worksData.map((p) => p.type));
+  return (['web', 'app', 'design'] as WorkCategory[]).filter((c) => present.has(c));
 }

--- a/pages/works/[id]/index.tsx
+++ b/pages/works/[id]/index.tsx
@@ -1,87 +1,397 @@
 import Head from 'next/head';
+import Image from 'next/image';
 import Link from 'next/link';
-import { ExternalLink, FileText, LifeBuoy, Megaphone } from 'lucide-react';
+import { useState, ReactNode } from 'react';
 import type { GetStaticPaths, GetStaticProps } from 'next';
+import {
+  ArrowLeft,
+  ArrowUpRight,
+  ExternalLink,
+  FileText,
+  LifeBuoy,
+  Megaphone,
+  MessageCircle,
+  Layers,
+  Palette,
+  Type,
+  Compass,
+} from 'lucide-react';
 import StaggerContainer, { StaggerItem } from '@/components/StaggerContainer';
-import WorkDetailLayout from '@/components/WorkDetailLayout';
-import { getAppProjects, getAppProjectById } from '@/lib/worksData';
-import type { AppProject } from '@/lib/worksData';
+import { worksData, getProjectById, categoryLabels } from '@/lib/worksData';
+import type { WorkProject } from '@/lib/worksData';
 
 interface Props {
-  project: AppProject;
+  project: WorkProject;
 }
 
-const navCards = [
+const appResources = [
   { key: 'spec', label: 'Specification', desc: 'Features & tech stack', icon: FileText },
   { key: 'support', label: 'Support', desc: 'FAQ & contact', icon: LifeBuoy },
   { key: 'marketing', label: 'Marketing', desc: 'Highlights & download', icon: Megaphone },
 ] as const;
 
-export default function WorkOverview({ project }: Props) {
+function Section({
+  index,
+  title,
+  icon: Icon,
+  children,
+}: {
+  index: string;
+  title: string;
+  icon: React.ComponentType<{ size?: number; className?: string }>;
+  children: ReactNode;
+}) {
+  return (
+    <section>
+      <StaggerItem>
+        <div className="flex items-center gap-3 mb-6">
+          <span className="font-mono text-xs text-white/40 tracking-widest">{index}</span>
+          <span className="h-px flex-1 max-w-12 bg-white/20" aria-hidden />
+          <Icon size={18} className="text-white/50" />
+          <h2 className="text-xl sm:text-2xl font-bold text-white/90 tracking-tight">{title}</h2>
+        </div>
+      </StaggerItem>
+      {children}
+    </section>
+  );
+}
+
+export default function WorkCaseStudy({ project }: Props) {
+  const { caseStudy } = project;
+  const [imgError, setImgError] = useState(false);
+  const showImage = project.image && !imgError;
+
   return (
     <>
       <Head>
-        <title>{`${project.title} - EternaxCode`}</title>
-        <meta name="description" content={project.description} />
+        <title>{`${project.title} - Case Study - EternaxCode`}</title>
+        <meta name="description" content={caseStudy.overview.summary} />
+        <meta property="og:title" content={`${project.title} - EternaxCode`} />
+        <meta property="og:description" content={caseStudy.tagline} />
+        {project.image && <meta property="og:image" content={project.image} />}
       </Head>
 
-      <WorkDetailLayout project={project} currentTab="overview">
-        <StaggerContainer className="space-y-8">
-          {/* Hero description */}
-          <StaggerItem>
-            <div className="rounded-2xl bg-white/5 border border-white/10 p-6 sm:p-8">
-              <p className="text-base sm:text-lg text-white/80 leading-relaxed">
-                {project.heroDescription}
-              </p>
-            </div>
-          </StaggerItem>
+      <div className="min-h-screen w-full flex flex-col items-center px-4 sm:px-8 pt-24 pb-20 text-white">
+        <div className="w-full max-w-4xl">
+          <StaggerContainer className="space-y-14 sm:space-y-16">
+            {/* ── Hero ── */}
+            <header>
+              <StaggerItem>
+                <Link
+                  href="/works"
+                  className="inline-flex items-center gap-2 text-sm text-white/60 hover:text-white/90 transition-colors mb-8"
+                >
+                  <ArrowLeft size={16} />
+                  Back to Works
+                </Link>
+              </StaggerItem>
 
-          {/* Nav cards grid */}
-          <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
-            {navCards.map((card) => {
-              const Icon = card.icon;
-              return (
-                <StaggerItem key={card.key}>
-                  <Link
-                    href={`/works/${project.id}/${card.key}`}
-                    className="group block rounded-2xl bg-white/5 border border-white/10 p-6 hover:bg-white/10 hover:border-white/20 transition-all duration-200"
+              <StaggerItem>
+                <div className="flex flex-wrap items-center gap-2 mb-4">
+                  <span className="text-xs font-semibold uppercase tracking-widest px-3 py-1 rounded-full bg-white/15 border border-white/20 text-white/90">
+                    {categoryLabels[project.type]}
+                  </span>
+                  {project.tags.map((tag) => (
+                    <span
+                      key={tag}
+                      className="text-xs font-medium px-3 py-1 rounded-full bg-white/5 border border-white/10 text-white/60"
+                    >
+                      {tag}
+                    </span>
+                  ))}
+                </div>
+                <h1 className="text-3xl sm:text-4xl md:text-5xl font-bold mb-3 bg-gradient-to-r from-white via-white/90 to-white/60 bg-clip-text text-transparent tracking-tight">
+                  {project.title}
+                </h1>
+                <p className="text-base sm:text-lg text-white/60 max-w-2xl leading-relaxed mb-6">
+                  {caseStudy.tagline}
+                </p>
+                {project.url !== '#' && (
+                  <a
+                    href={project.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="inline-flex items-center gap-2 px-5 py-2.5 rounded-full bg-white/10 border border-white/20 text-sm font-medium text-white/90 hover:bg-white/20 transition-all duration-200"
                   >
-                    <Icon size={24} className="text-white/60 group-hover:text-white/90 mb-3 transition-colors" />
-                    <h3 className="text-base font-semibold text-white/90 mb-1">{card.label}</h3>
-                    <p className="text-sm text-white/50">{card.desc}</p>
-                  </Link>
-                </StaggerItem>
-              );
-            })}
-          </div>
+                    {project.type === 'app' ? 'Download' : 'Visit Live Site'}
+                    <ExternalLink size={15} />
+                  </a>
+                )}
+              </StaggerItem>
 
-          {/* External link */}
-          {project.url !== '#' && (
+              {showImage && (
+                <StaggerItem className="mt-10">
+                  <div
+                    className="relative aspect-video w-full overflow-hidden rounded-2xl border border-white/10"
+                    style={{ boxShadow: `0 20px 80px -20px ${project.accentColor}` }}
+                  >
+                    <Image
+                      src={project.image!}
+                      alt={project.title}
+                      fill
+                      className="object-cover"
+                      unoptimized
+                      onError={() => setImgError(true)}
+                    />
+                  </div>
+                </StaggerItem>
+              )}
+            </header>
+
+            {/* ── 01 Overview ── */}
+            <Section index="01" title="Overview" icon={Compass}>
+              <div className="space-y-6">
+                <StaggerItem>
+                  <div className="rounded-2xl bg-white/5 border border-white/10 p-6 sm:p-8">
+                    <p className="text-base sm:text-lg text-white/80 leading-relaxed">
+                      {caseStudy.overview.summary}
+                    </p>
+                  </div>
+                </StaggerItem>
+
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                  <StaggerItem>
+                    <div className="h-full rounded-2xl bg-white/5 border border-white/10 p-6">
+                      <h3 className="text-xs font-semibold uppercase tracking-widest text-white/40 mb-3">
+                        Challenge
+                      </h3>
+                      <p className="text-sm text-white/70 leading-relaxed">
+                        {caseStudy.overview.challenge}
+                      </p>
+                    </div>
+                  </StaggerItem>
+                  <StaggerItem>
+                    <div className="h-full rounded-2xl bg-white/5 border border-white/10 p-6">
+                      <h3 className="text-xs font-semibold uppercase tracking-widest text-white/40 mb-3">
+                        Approach
+                      </h3>
+                      <p className="text-sm text-white/70 leading-relaxed">
+                        {caseStudy.overview.approach}
+                      </p>
+                    </div>
+                  </StaggerItem>
+                </div>
+
+                <StaggerItem>
+                  <h3 className="text-xs font-semibold uppercase tracking-widest text-white/40 mb-3">
+                    Scope of Work
+                  </h3>
+                  <div className="flex flex-wrap gap-2">
+                    {caseStudy.overview.scope.map((item) => (
+                      <span
+                        key={item}
+                        className="text-xs font-medium px-3 py-1.5 rounded-full bg-white/10 text-white/70 border border-white/10"
+                      >
+                        {item}
+                      </span>
+                    ))}
+                  </div>
+                </StaggerItem>
+              </div>
+            </Section>
+
+            {/* ── 02 Design System ── */}
+            <Section index="02" title="Design System" icon={Palette}>
+              <div className="space-y-8">
+                <StaggerItem>
+                  <p className="text-base text-white/70 leading-relaxed max-w-2xl">
+                    {caseStudy.designSystem.concept}
+                  </p>
+                </StaggerItem>
+
+                {/* Color palette */}
+                <StaggerItem>
+                  <h3 className="text-xs font-semibold uppercase tracking-widest text-white/40 mb-4">
+                    Color Palette
+                  </h3>
+                  <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
+                    {caseStudy.designSystem.colors.map((color) => (
+                      <div
+                        key={color.name}
+                        className="rounded-2xl bg-white/5 border border-white/10 overflow-hidden"
+                      >
+                        <div className="h-20 w-full" style={{ backgroundColor: color.hex }} />
+                        <div className="p-4">
+                          <p className="text-sm font-semibold text-white/90">{color.name}</p>
+                          <p className="font-mono text-xs text-white/50 mt-0.5">{color.hex}</p>
+                          <p className="text-xs text-white/50 mt-2 leading-relaxed">{color.role}</p>
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                </StaggerItem>
+
+                {/* Typography */}
+                <StaggerItem>
+                  <h3 className="text-xs font-semibold uppercase tracking-widest text-white/40 mb-4">
+                    Typography
+                  </h3>
+                  <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                    {caseStudy.designSystem.typography.map((type) => (
+                      <div
+                        key={type.family}
+                        className="rounded-2xl bg-white/5 border border-white/10 p-6 flex items-start gap-4"
+                      >
+                        <Type size={20} className="text-white/40 mt-1 shrink-0" />
+                        <div>
+                          <p className="text-base font-semibold text-white/90">{type.family}</p>
+                          <p className="text-sm text-white/60 mt-1 leading-relaxed">{type.usage}</p>
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                </StaggerItem>
+
+                {/* Design principles */}
+                <StaggerItem>
+                  <h3 className="text-xs font-semibold uppercase tracking-widest text-white/40 mb-4">
+                    Design Principles
+                  </h3>
+                  <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+                    {caseStudy.designSystem.principles.map((principle, i) => (
+                      <div
+                        key={principle.title}
+                        className="rounded-2xl bg-white/5 border border-white/10 p-6"
+                      >
+                        <span className="font-mono text-xs text-white/30">
+                          {String(i + 1).padStart(2, '0')}
+                        </span>
+                        <h4 className="text-sm font-semibold text-white/90 mt-2 mb-2">
+                          {principle.title}
+                        </h4>
+                        <p className="text-xs text-white/55 leading-relaxed">
+                          {principle.description}
+                        </p>
+                      </div>
+                    ))}
+                  </div>
+                </StaggerItem>
+              </div>
+            </Section>
+
+            {/* ── 03 Stack & Deliverables ── */}
+            <Section index="03" title="Stack & Deliverables" icon={Layers}>
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                <StaggerItem>
+                  <div className="h-full rounded-2xl bg-white/5 border border-white/10 p-6">
+                    <h3 className="text-xs font-semibold uppercase tracking-widest text-white/40 mb-4">
+                      Tech Stack
+                    </h3>
+                    <div className="flex flex-wrap gap-2">
+                      {caseStudy.techStack.map((tech) => (
+                        <span
+                          key={tech}
+                          className="text-xs font-medium px-3 py-1.5 rounded-full bg-white/10 text-white/70 border border-white/10"
+                        >
+                          {tech}
+                        </span>
+                      ))}
+                    </div>
+                  </div>
+                </StaggerItem>
+                <StaggerItem>
+                  <div className="h-full rounded-2xl bg-white/5 border border-white/10 p-6">
+                    <h3 className="text-xs font-semibold uppercase tracking-widest text-white/40 mb-4">
+                      Deliverables
+                    </h3>
+                    <ul className="space-y-2">
+                      {caseStudy.deliverables.map((item) => (
+                        <li key={item} className="flex items-center gap-2.5 text-sm text-white/70">
+                          <span
+                            className="w-1.5 h-1.5 rounded-full shrink-0"
+                            style={{ backgroundColor: project.accentColor.replace('0.4', '0.9') }}
+                          />
+                          {item}
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                </StaggerItem>
+              </div>
+            </Section>
+
+            {/* ── 04 Links ── */}
+            <Section index="04" title="Links" icon={ArrowUpRight}>
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                {caseStudy.links.map((link) => (
+                  <StaggerItem key={link.url}>
+                    <a
+                      href={link.url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="group flex items-center justify-between rounded-2xl bg-white/5 border border-white/10 p-6 hover:bg-white/10 hover:border-white/20 transition-all duration-200"
+                    >
+                      <div>
+                        <p className="text-base font-semibold text-white/90">{link.label}</p>
+                        <p className="text-sm text-white/50 mt-0.5">{link.description}</p>
+                      </div>
+                      <ArrowUpRight
+                        size={20}
+                        className="text-white/40 group-hover:text-white/90 group-hover:translate-x-0.5 group-hover:-translate-y-0.5 transition-all shrink-0"
+                      />
+                    </a>
+                  </StaggerItem>
+                ))}
+              </div>
+
+              {/* App-only resource pages */}
+              {project.type === 'app' && (
+                <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 mt-4">
+                  {appResources.map((card) => {
+                    const Icon = card.icon;
+                    return (
+                      <StaggerItem key={card.key}>
+                        <Link
+                          href={`/works/${project.id}/${card.key}`}
+                          className="group block h-full rounded-2xl bg-white/5 border border-white/10 p-6 hover:bg-white/10 hover:border-white/20 transition-all duration-200"
+                        >
+                          <Icon
+                            size={22}
+                            className="text-white/60 group-hover:text-white/90 mb-3 transition-colors"
+                          />
+                          <h3 className="text-sm font-semibold text-white/90 mb-1">{card.label}</h3>
+                          <p className="text-xs text-white/50">{card.desc}</p>
+                        </Link>
+                      </StaggerItem>
+                    );
+                  })}
+                </div>
+              )}
+            </Section>
+
+            {/* ── CTA ── */}
             <StaggerItem>
-              <a
-                href={project.url}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="inline-flex items-center gap-2 px-6 py-3 rounded-full bg-white/10 border border-white/20 text-sm font-medium text-white/90 hover:bg-white/20 transition-all duration-200"
-              >
-                Visit {project.title}
-                <ExternalLink size={16} />
-              </a>
+              <div className="rounded-2xl bg-gradient-to-br from-white/10 to-white/5 border border-white/15 p-8 sm:p-10 text-center">
+                <MessageCircle size={24} className="text-white/60 mx-auto mb-4" />
+                <h2 className="text-xl sm:text-2xl font-bold text-white/90 mb-2">
+                  Have a project in mind?
+                </h2>
+                <p className="text-sm sm:text-base text-white/60 mb-6 max-w-md mx-auto leading-relaxed">
+                  From web platforms to mobile apps and brand design — we can build it together.
+                </p>
+                <Link
+                  href="/contact"
+                  className="inline-flex items-center gap-2 px-6 py-3 rounded-full bg-white/15 border border-white/25 text-sm font-semibold text-white hover:bg-white/25 transition-all duration-200"
+                >
+                  Start a Conversation
+                  <ArrowUpRight size={16} />
+                </Link>
+              </div>
             </StaggerItem>
-          )}
-        </StaggerContainer>
-      </WorkDetailLayout>
+          </StaggerContainer>
+        </div>
+      </div>
     </>
   );
 }
 
 export const getStaticPaths: GetStaticPaths = async () => {
-  const paths = getAppProjects().map((p) => ({ params: { id: p.id } }));
+  const paths = worksData.map((p) => ({ params: { id: p.id } }));
   return { paths, fallback: false };
 };
 
 export const getStaticProps: GetStaticProps<Props> = async ({ params }) => {
-  const project = getAppProjectById(params!.id as string);
+  const project = getProjectById(params!.id as string);
   if (!project) return { notFound: true };
   return { props: { project } };
 };

--- a/pages/works/index.tsx
+++ b/pages/works/index.tsx
@@ -1,24 +1,77 @@
+'use client';
+
 import Head from 'next/head';
-import { Package } from 'lucide-react';
+import { useMemo, useState } from 'react';
+import { AnimatePresence, motion } from 'framer-motion';
+import { Package, Globe, Smartphone, Palette } from 'lucide-react';
 import StaggerContainer, { StaggerItem } from '@/components/StaggerContainer';
 import WorkCard from '@/components/WorkCard';
-import { worksData } from '@/lib/worksData';
+import { worksData, getCategories, categoryLabels } from '@/lib/worksData';
+import type { WorkCategory } from '@/lib/worksData';
+
+const capabilities: {
+  category: WorkCategory;
+  title: string;
+  description: string;
+  icon: React.ComponentType<{ size?: number; className?: string }>;
+}[] = [
+  {
+    category: 'web',
+    title: 'Web Development',
+    icon: Globe,
+    description:
+      'Brand sites, AI-powered platforms, and web services — designed and engineered end-to-end with modern stacks.',
+  },
+  {
+    category: 'app',
+    title: 'Mobile Apps',
+    icon: Smartphone,
+    description:
+      'Cross-platform iOS & Android apps, from product design to App Store launch, built with privacy-first architecture.',
+  },
+  {
+    category: 'design',
+    title: 'UI/UX & Brand Design',
+    icon: Palette,
+    description:
+      'Design systems, brand identities, and interfaces that give every product a distinct, professional presence.',
+  },
+];
+
+type Filter = 'all' | WorkCategory;
 
 export default function Works() {
+  const [filter, setFilter] = useState<Filter>('all');
+
+  const categories = useMemo(() => getCategories(), []);
+  const filtered = useMemo(
+    () => (filter === 'all' ? worksData : worksData.filter((p) => p.type === filter)),
+    [filter],
+  );
+
+  const filters: { key: Filter; label: string; count: number }[] = [
+    { key: 'all', label: 'All', count: worksData.length },
+    ...categories.map((c) => ({
+      key: c as Filter,
+      label: categoryLabels[c],
+      count: worksData.filter((p) => p.type === c).length,
+    })),
+  ];
+
   return (
     <>
       <Head>
         <title>Works - EternaxCode</title>
         <meta
           name="description"
-          content="Explore projects built by EternaxCode — from branded web experiences to AI-powered platforms."
+          content="Explore case studies by EternaxCode — web platforms, mobile apps, and design systems, each documented with overview, design system, and references."
         />
       </Head>
 
-      <div className="min-h-screen w-full flex flex-col items-center p-4 sm:p-8 pt-24 text-white">
+      <div className="min-h-screen w-full flex flex-col items-center p-4 sm:p-8 pt-24 pb-20 text-white">
         <StaggerContainer className="w-full max-w-6xl">
           {/* Header */}
-          <StaggerItem className="text-center mb-10 sm:mb-14">
+          <StaggerItem className="text-center mb-10 sm:mb-12">
             <div className="inline-flex items-center gap-2 px-4 py-2 rounded-full bg-white/10 border border-white/20 text-xs sm:text-sm text-white/80 mb-6">
               <Package size={14} />
               Portfolio
@@ -27,18 +80,73 @@ export default function Works() {
               Selected Works
             </h1>
             <p className="text-sm sm:text-base text-white/60 max-w-xl mx-auto leading-relaxed">
-              A collection of projects we&apos;ve crafted — each built with modern technologies and a focus on great user experience.
+              Case studies across web, app, and design — each documented with a service overview,
+              design system, and references so you can see exactly how we work.
             </p>
           </StaggerItem>
 
-          {/* Project Grid */}
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 sm:gap-8">
-            {worksData.map((project) => (
-              <StaggerItem key={project.id}>
-                <WorkCard project={project} />
-              </StaggerItem>
-            ))}
+          {/* Capabilities */}
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 mb-12 sm:mb-14">
+            {capabilities.map((cap) => {
+              const Icon = cap.icon;
+              return (
+                <StaggerItem key={cap.category}>
+                  <div className="h-full rounded-2xl bg-white/5 border border-white/10 p-6">
+                    <Icon size={22} className="text-white/70 mb-3" />
+                    <h2 className="text-base font-semibold text-white/90 mb-2">{cap.title}</h2>
+                    <p className="text-sm text-white/55 leading-relaxed">{cap.description}</p>
+                  </div>
+                </StaggerItem>
+              );
+            })}
           </div>
+
+          {/* Category filter */}
+          <StaggerItem className="flex flex-wrap justify-center gap-2 mb-8 sm:mb-10">
+            {filters.map((f) => {
+              const isActive = filter === f.key;
+              return (
+                <button
+                  key={f.key}
+                  onClick={() => setFilter(f.key)}
+                  className={`
+                    inline-flex items-center gap-2 px-4 py-2 rounded-full text-sm font-medium
+                    border cursor-pointer transition-all duration-200
+                    ${
+                      isActive
+                        ? 'bg-white/20 text-white border-white/25 ring-1 ring-white/20'
+                        : 'bg-transparent text-white/60 border-white/10 hover:text-white hover:bg-white/10'
+                    }
+                  `}
+                >
+                  {f.label}
+                  <span
+                    className={`text-xs font-mono ${isActive ? 'text-white/70' : 'text-white/40'}`}
+                  >
+                    {f.count}
+                  </span>
+                </button>
+              );
+            })}
+          </StaggerItem>
+
+          {/* Project Grid */}
+          <motion.div layout className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 sm:gap-8">
+            <AnimatePresence mode="popLayout">
+              {filtered.map((project) => (
+                <motion.div
+                  key={project.id}
+                  layout
+                  initial={{ opacity: 0, scale: 0.95 }}
+                  animate={{ opacity: 1, scale: 1 }}
+                  exit={{ opacity: 0, scale: 0.95 }}
+                  transition={{ duration: 0.25, ease: 'easeOut' }}
+                >
+                  <WorkCard project={project} />
+                </motion.div>
+              ))}
+            </AnimatePresence>
+          </motion.div>
         </StaggerContainer>
       </div>
     </>


### PR DESCRIPTION
- 모든 프로젝트(웹/앱)에 서비스 개요, 디자인 시스템, 링크를 담은
  케이스 스터디 상세 페이지 도입 (/works/[id])
- 데이터 모델에 CaseStudy(개요/과제/접근/범위, 컬러 팔레트,
  타이포그래피, 디자인 원칙, 산출물, 링크) 및 design 카테고리 확장
- Works 페이지에 전문 분야(Web/App/Design) 소개 섹션과
  카테고리 필터 추가
- WorkCard에 카테고리 배지 추가, 모든 카드가 상세 페이지로 연결
- 상세 페이지 하단에 프로젝트 문의 CTA 추가

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01TTZV2Jp4gdsSwZSwdmJKSg